### PR TITLE
Add external cache if present

### DIFF
--- a/stormpath.go
+++ b/stormpath.go
@@ -67,6 +67,8 @@ func Init(clientConfiguration ClientConfiguration, cache Cache) {
 
 	if clientConfiguration.CacheManagerEnabled && cache == nil {
 		client.Cache = NewLocalCache(clientConfiguration.CacheTTL, clientConfiguration.CacheTTI)
+	} else if clientConfiguration.CacheManagerEnabled && cache != nil {
+		client.Cache = cache
 	}
 }
 


### PR DESCRIPTION
Fixes a lapse. User provided caches were ignored.