### PR TITLE
Add 'LoadConfigurationWithCreds' function

### DIFF
--- a/config.go
+++ b/config.go
@@ -52,22 +52,7 @@ type ClientConfiguration struct {
 
 //LoadConfiguration loads the configuration from the default locations
 func LoadConfiguration() (ClientConfiguration, error) {
-	c := ClientConfiguration{
-		APIKeyFile:           "",
-		APIKeyID:             "",
-		APIKeySecret:         "",
-		CacheManagerEnabled:  true,
-		CacheTTI:             300 * time.Second,
-		CacheTTL:             300 * time.Second,
-		BaseURL:              "https://api.stormpath.com/v1/",
-		ConnectionTimeout:    30,
-		AuthenticationScheme: "SAUTHC1",
-		ProxyHost:            "",
-		ProxyPort:            0,
-		ProxyUsername:        "",
-		ProxyPassword:        "",
-	}
-
+	c := newDefaultClientConfiguration()
 	v := viper.New()
 
 	v.SetConfigType("yaml")
@@ -119,6 +104,14 @@ func LoadConfiguration() (ClientConfiguration, error) {
 	return c, nil
 }
 
+func LoadConfigurationWithCreds(key string, secret string) ClientConfiguration {
+	c := newDefaultClientConfiguration()
+	c.APIKeyID = key
+	c.APIKeySecret = secret
+
+	return c
+}
+
 func loadCredentials(extraFileLocation string) (id string, secret string, err error) {
 	id = os.Getenv("STORMPATH_API_KEY_ID")
 	secret = os.Getenv("STORMPATH_API_KEY_SECRET")
@@ -145,4 +138,22 @@ func loadCredentials(extraFileLocation string) (id string, secret string, err er
 //GetJWTSigningKey returns the API Key Secret as a []byte to sign JWT tokens
 func (config ClientConfiguration) GetJWTSigningKey() []byte {
 	return []byte(config.APIKeySecret)
+}
+
+func newDefaultClientConfiguration() (c ClientConfiguration) {
+	return ClientConfiguration{
+		APIKeyFile:           "",
+		APIKeyID:             "",
+		APIKeySecret:         "",
+		CacheManagerEnabled:  true,
+		CacheTTI:             300 * time.Second,
+		CacheTTL:             300 * time.Second,
+		BaseURL:              "https://api.stormpath.com/v1/",
+		ConnectionTimeout:    30,
+		AuthenticationScheme: "SAUTHC1",
+		ProxyHost:            "",
+		ProxyPort:            0,
+		ProxyUsername:        "",
+		ProxyPassword:        "",
+	}
 }


### PR DESCRIPTION
'LoadConfigurationWithCreds' takes stormpath api key & secret as params to bypass loading it from config files. I'm using stormpath as a middleware in Gin and the middleware is being loaded in couple different places. To avoid copying apiKey.properties to all those place I figured I'll pass it instead, hence this PR.

According to https://github.com/stormpath/stormpath-sdk-spec/blob/master/specifications/config.md, Node.js SDK loads the creds as part of constructor; though this is not the constructor, I believe it applies here as well.

Using this would bypass all apikeys.properties. If you want I can make it so it loads them it exists and then overrides key/secret with the passed in variables. It wasn't required for my use case so I didn't bother adding it.

Best!