### PR TITLE
Graceful cleanup of tests in case of errors.

### DIFF
--- a/account_creation_policy_test.go
+++ b/account_creation_policy_test.go
@@ -22,7 +22,7 @@ func TestGetVerificationEmailTemplatesPolicyNoExists(t *testing.T) {
 func TestGetVerificationEmailTemplates(t *testing.T) {
 	t.Parallel()
 
-	directory := createTestDirectory()
+	directory := createTestDirectory(t)
 	defer directory.Delete()
 
 	policy, _ := directory.GetAccountCreationPolicy()
@@ -49,7 +49,7 @@ func TestGetVerificationSuccessEmailTemplatesPolicyNoExists(t *testing.T) {
 func TestGetVerificationSuccessEmailTemplates(t *testing.T) {
 	t.Parallel()
 
-	directory := createTestDirectory()
+	directory := createTestDirectory(t)
 	defer directory.Delete()
 
 	policy, _ := directory.GetAccountCreationPolicy()
@@ -76,7 +76,7 @@ func TestGetWelcomeEmailTemplatesPolicyNoExists(t *testing.T) {
 func TestGetWelcomeEmailTemplates(t *testing.T) {
 	t.Parallel()
 
-	directory := createTestDirectory()
+	directory := createTestDirectory(t)
 	defer directory.Delete()
 
 	policy, _ := directory.GetAccountCreationPolicy()
@@ -90,7 +90,7 @@ func TestGetWelcomeEmailTemplates(t *testing.T) {
 func TestUpdateAccountCreationPolicy(t *testing.T) {
 	t.Parallel()
 
-	directory := createTestDirectory()
+	directory := createTestDirectory(t)
 	defer directory.Delete()
 
 	policy, _ := directory.GetAccountCreationPolicy()
@@ -116,7 +116,7 @@ func TestUpdateAccountCreationPolicyNoExists(t *testing.T) {
 func TestRefreshAccountCreationPolicy(t *testing.T) {
 	t.Parallel()
 
-	directory := createTestDirectory()
+	directory := createTestDirectory(t)
 	defer directory.Delete()
 
 	policy, _ := directory.GetAccountCreationPolicy()

--- a/account_store_mapping_test.go
+++ b/account_store_mapping_test.go
@@ -21,10 +21,10 @@ func TestAccountStoreMappingJsonMarshaling(t *testing.T) {
 func TestSaveAccountStoreMapping(t *testing.T) {
 	t.Parallel()
 
-	application := createTestApplication()
+	application := createTestApplication(t)
 	defer application.Purge()
 
-	directory := createTestDirectory()
+	directory := createTestDirectory(t)
 	defer directory.Delete()
 
 	asm := NewApplicationAccountStoreMapping(application.Href, directory.Href)
@@ -37,7 +37,7 @@ func TestSaveAccountStoreMapping(t *testing.T) {
 func TestSaveAccountStoreMappingApplicationNoExists(t *testing.T) {
 	t.Parallel()
 
-	directory := createTestDirectory()
+	directory := createTestDirectory(t)
 	defer directory.Delete()
 
 	asm := NewApplicationAccountStoreMapping(GetClient().ClientConfiguration.BaseURL+"applications/XXX", directory.Href)
@@ -51,7 +51,7 @@ func TestSaveAccountStoreMappingApplicationNoExists(t *testing.T) {
 func TestSaveAccountStoreMappingDirectoryNoExists(t *testing.T) {
 	t.Parallel()
 
-	application := createTestApplication()
+	application := createTestApplication(t)
 	defer application.Purge()
 
 	asm := NewApplicationAccountStoreMapping(application.Href, GetClient().ClientConfiguration.BaseURL+"directories/XXX")

--- a/account_test.go
+++ b/account_test.go
@@ -10,10 +10,10 @@ import (
 func TestGetAccountRefreshTokens(t *testing.T) {
 	t.Parallel()
 
-	application := createTestApplication()
+	application := createTestApplication(t)
 	defer application.Purge()
 
-	account := createTestAccount(application)
+	account := createTestAccount(application, t)
 
 	application.GetOAuthToken(account.Username, "1234567z!A89")
 
@@ -29,10 +29,10 @@ func TestGetAccountRefreshTokens(t *testing.T) {
 func TestGetAccountAccessTokens(t *testing.T) {
 	t.Parallel()
 
-	application := createTestApplication()
+	application := createTestApplication(t)
 	defer application.Purge()
 
-	account := createTestAccount(application)
+	account := createTestAccount(application, t)
 
 	application.GetOAuthToken(account.Username, "1234567z!A89")
 
@@ -48,10 +48,10 @@ func TestGetAccountAccessTokens(t *testing.T) {
 func TestRevokeAccountAccessToken(t *testing.T) {
 	t.Parallel()
 
-	application := createTestApplication()
+	application := createTestApplication(t)
 	defer application.Purge()
 
-	account := createTestAccount(application)
+	account := createTestAccount(application, t)
 
 	application.GetOAuthToken(account.Username, "1234567z!A89")
 
@@ -87,10 +87,10 @@ func TestGetAccountNoExists(t *testing.T) {
 func TestGetAccount(t *testing.T) {
 	t.Parallel()
 
-	application := createTestApplication()
+	application := createTestApplication(t)
 	defer application.Purge()
 
-	newAccount := createTestAccount(application)
+	newAccount := createTestAccount(application, t)
 
 	account, err := GetAccount(newAccount.Href, MakeAccountCriteria())
 
@@ -111,7 +111,7 @@ func TestVerifyInvalidEmailToken(t *testing.T) {
 func TestVerifyValidEmailToken(t *testing.T) {
 	t.Parallel()
 
-	directory := createTestDirectory()
+	directory := createTestDirectory(t)
 	defer directory.Delete()
 
 	policy, _ := directory.GetAccountCreationPolicy()
@@ -135,10 +135,10 @@ func TestVerifyValidEmailToken(t *testing.T) {
 func TestAccountUpdate(t *testing.T) {
 	t.Parallel()
 
-	application := createTestApplication()
+	application := createTestApplication(t)
 	defer application.Purge()
 
-	account := createTestAccount(application)
+	account := createTestAccount(application, t)
 
 	account.GivenName = "julio"
 	err := account.Update()
@@ -154,10 +154,10 @@ func TestAccountUpdate(t *testing.T) {
 func TestAccountDelete(t *testing.T) {
 	t.Parallel()
 
-	application := createTestApplication()
+	application := createTestApplication(t)
 	defer application.Purge()
 
-	account := createTestAccount(application)
+	account := createTestAccount(application, t)
 
 	err := account.Delete()
 
@@ -167,13 +167,13 @@ func TestAccountDelete(t *testing.T) {
 func TestAddAccountToGroup(t *testing.T) {
 	t.Parallel()
 
-	application := createTestApplication()
+	application := createTestApplication(t)
 	defer application.Purge()
 
-	group := createTestGroup(application)
+	group := createTestGroup(application, t)
 	defer group.Delete()
 
-	account := createTestAccount(application)
+	account := createTestAccount(application, t)
 
 	_, err := account.AddToGroup(group)
 
@@ -188,14 +188,14 @@ func TestAddAccountToGroup(t *testing.T) {
 func TestRemoveAccountFromGroup(t *testing.T) {
 	t.Parallel()
 
-	application := createTestApplication()
+	application := createTestApplication(t)
 	defer application.Purge()
 
 	var groupCountBefore int
-	group := createTestGroup(application)
+	group := createTestGroup(application, t)
 	defer group.Delete()
 
-	account := createTestAccount(application)
+	account := createTestAccount(application, t)
 
 	gm, _ := account.GetGroupMemberships(MakeAccountCriteria().Offset(0).Limit(25))
 	groupCountBefore = len(gm.Items)
@@ -212,13 +212,13 @@ func TestRemoveAccountFromGroup(t *testing.T) {
 func TestExpandGroupMembershipsAccount(t *testing.T) {
 	t.Parallel()
 
-	application := createTestApplication()
+	application := createTestApplication(t)
 	defer application.Purge()
 
-	group := createTestGroup(application)
+	group := createTestGroup(application, t)
 	defer group.Delete()
 
-	account := createTestAccount(application)
+	account := createTestAccount(application, t)
 
 	groupMemberships, err := account.GetGroupMemberships(MakeGroupMemershipCriteria().WithAccount().Offset(0).Limit(25))
 
@@ -232,10 +232,10 @@ func TestExpandGroupMembershipsAccount(t *testing.T) {
 func TestGetAccountCustomData(t *testing.T) {
 	t.Parallel()
 
-	application := createTestApplication()
+	application := createTestApplication(t)
 	defer application.Purge()
 
-	account := createTestAccount(application)
+	account := createTestAccount(application, t)
 
 	customData, err := account.GetCustomData()
 
@@ -259,10 +259,10 @@ func TestGetNoExistsAccountCustomData(t *testing.T) {
 func TestUpdateAccountCustomData(t *testing.T) {
 	t.Parallel()
 
-	application := createTestApplication()
+	application := createTestApplication(t)
 	defer application.Purge()
 
-	account := createTestAccount(application)
+	account := createTestAccount(application, t)
 
 	customData, err := account.UpdateCustomData(map[string]interface{}{"custom": "data"})
 

--- a/api_keys_test.go
+++ b/api_keys_test.go
@@ -10,10 +10,10 @@ import (
 func TestGetAPIKey(t *testing.T) {
 	t.Parallel()
 
-	application := createTestApplication()
+	application := createTestApplication(t)
 	defer application.Purge()
 
-	account := createTestAccount(application)
+	account := createTestAccount(application, t)
 
 	apiKey, _ := account.CreateAPIKey()
 
@@ -26,10 +26,10 @@ func TestGetAPIKey(t *testing.T) {
 func TestDeleteAPIKey(t *testing.T) {
 	t.Parallel()
 
-	application := createTestApplication()
+	application := createTestApplication(t)
 	defer application.Purge()
 
-	account := createTestAccount(application)
+	account := createTestAccount(application, t)
 
 	apiKey, _ := account.CreateAPIKey()
 
@@ -47,10 +47,10 @@ func TestDeleteAPIKey(t *testing.T) {
 func TestUpdateAPIKey(t *testing.T) {
 	t.Parallel()
 
-	application := createTestApplication()
+	application := createTestApplication(t)
 	defer application.Purge()
 
-	account := createTestAccount(application)
+	account := createTestAccount(application, t)
 
 	apiKey, _ := account.CreateAPIKey()
 

--- a/application_test.go
+++ b/application_test.go
@@ -14,10 +14,10 @@ import (
 func TestGetOAuthTokenValidAccount(t *testing.T) {
 	t.Parallel()
 
-	application := createTestApplication()
+	application := createTestApplication(t)
 	defer application.Purge()
 
-	account := createTestAccount(application)
+	account := createTestAccount(application, t)
 
 	oauthResponse, err := application.GetOAuthToken(account.Username, "1234567z!A89")
 
@@ -31,10 +31,10 @@ func TestGetOAuthTokenValidAccount(t *testing.T) {
 func TestRefreshOAuthTokenValidAccount(t *testing.T) {
 	t.Parallel()
 
-	application := createTestApplication()
+	application := createTestApplication(t)
 	defer application.Purge()
 
-	account := createTestAccount(application)
+	account := createTestAccount(application, t)
 
 	oauthResponse, err := application.GetOAuthToken(account.Username, "1234567z!A89")
 
@@ -58,10 +58,10 @@ func TestRefreshOAuthTokenValidAccount(t *testing.T) {
 func TestValidateOAuthAccessToken(t *testing.T) {
 	t.Parallel()
 
-	application := createTestApplication()
+	application := createTestApplication(t)
 	defer application.Purge()
 
-	account := createTestAccount(application)
+	account := createTestAccount(application, t)
 
 	response, err := application.GetOAuthToken(account.Username, "1234567z!A89")
 	token, err := application.ValidateToken(response.AccessToken)
@@ -74,7 +74,7 @@ func TestValidateOAuthAccessToken(t *testing.T) {
 func TestValidateOAuthInvalidAccessToken(t *testing.T) {
 	t.Parallel()
 
-	application := createTestApplication()
+	application := createTestApplication(t)
 	defer application.Purge()
 
 	_, err := application.ValidateToken("anInvalidToken")
@@ -96,7 +96,7 @@ func TestApplicationJsonMarshaling(t *testing.T) {
 func TestUpdateApplication(t *testing.T) {
 	t.Parallel()
 
-	application := createTestApplication()
+	application := createTestApplication(t)
 	defer application.Purge()
 
 	application.Name = "new-name" + randomName()
@@ -113,7 +113,7 @@ func TestUpdateApplication(t *testing.T) {
 func TestApplicationRegisterAccount(t *testing.T) {
 	t.Parallel()
 
-	application := createTestApplication()
+	application := createTestApplication(t)
 	defer application.Purge()
 
 	account := newTestAccount()
@@ -126,10 +126,10 @@ func TestApplicationRegisterAccount(t *testing.T) {
 func TestAuthenticateAccount(t *testing.T) {
 	t.Parallel()
 
-	application := createTestApplication()
+	application := createTestApplication(t)
 	defer application.Purge()
 
-	account := createTestAccount(application)
+	account := createTestAccount(application, t)
 
 	authenticatedAccount, err := application.AuthenticateAccount(account.Email, "1234567z!A89", "")
 
@@ -143,7 +143,7 @@ func TestAuthenticateAccount(t *testing.T) {
 func TestApplicationCreateInvalidGroup(t *testing.T) {
 	t.Parallel()
 
-	application := createTestApplication()
+	application := createTestApplication(t)
 	defer application.Purge()
 
 	err := application.CreateGroup(&Group{})
@@ -155,7 +155,7 @@ func TestApplicationCreateInvalidGroup(t *testing.T) {
 func TestApplicationCreateGroup(t *testing.T) {
 	t.Parallel()
 
-	application := createTestApplication()
+	application := createTestApplication(t)
 	defer application.Purge()
 
 	group := newTestGroup()
@@ -171,10 +171,10 @@ func TestApplicationCreateGroup(t *testing.T) {
 func TestGetApplicationGroups(t *testing.T) {
 	t.Parallel()
 
-	application := createTestApplication()
+	application := createTestApplication(t)
 	defer application.Purge()
 
-	group := createTestGroup(application)
+	group := createTestGroup(application, t)
 	defer group.Delete()
 
 	groups, err := application.GetGroups(MakeGroupCriteria())
@@ -189,10 +189,10 @@ func TestGetApplicationGroups(t *testing.T) {
 func TestSendPasswordResetEmail(t *testing.T) {
 	t.Parallel()
 
-	application := createTestApplication()
+	application := createTestApplication(t)
 	defer application.Purge()
 
-	account := createTestAccount(application)
+	account := createTestAccount(application, t)
 
 	token, err := application.SendPasswordResetEmail(account.Email)
 
@@ -203,10 +203,10 @@ func TestSendPasswordResetEmail(t *testing.T) {
 func TestResetPassword(t *testing.T) {
 	t.Parallel()
 
-	application := createTestApplication()
+	application := createTestApplication(t)
 	defer application.Purge()
 
-	account := createTestAccount(application)
+	account := createTestAccount(application, t)
 
 	token, _ := application.SendPasswordResetEmail(account.Email)
 
@@ -221,10 +221,10 @@ func TestResetPassword(t *testing.T) {
 func TestValidatePasswordResetToken(t *testing.T) {
 	t.Parallel()
 
-	application := createTestApplication()
+	application := createTestApplication(t)
 	defer application.Purge()
 
-	account := createTestAccount(application)
+	account := createTestAccount(application, t)
 
 	token, _ := application.SendPasswordResetEmail(account.Email)
 
@@ -239,7 +239,7 @@ func TestValidatePasswordResetToken(t *testing.T) {
 func TestValidateInvalidPasswordResetToken(t *testing.T) {
 	t.Parallel()
 
-	application := createTestApplication()
+	application := createTestApplication(t)
 	defer application.Purge()
 
 	_, err := application.ValidatePasswordResetToken("invalid token")
@@ -250,7 +250,7 @@ func TestValidateInvalidPasswordResetToken(t *testing.T) {
 func TestCreateIDSiteURL(t *testing.T) {
 	t.Parallel()
 
-	application := createTestApplication()
+	application := createTestApplication(t)
 	defer application.Purge()
 
 	idSiteOptions := IDSiteOptions{
@@ -286,7 +286,7 @@ func TestCreateIDSiteURL(t *testing.T) {
 func TestCreateIDSiteLogoutURL(t *testing.T) {
 	t.Parallel()
 
-	application := createTestApplication()
+	application := createTestApplication(t)
 	defer application.Purge()
 
 	idSiteOptions := IDSiteOptions{
@@ -323,7 +323,7 @@ func TestCreateIDSiteLogoutURL(t *testing.T) {
 func TestGetApplicationDefaultAccountStoreMapping(t *testing.T) {
 	t.Parallel()
 
-	application := createTestApplication()
+	application := createTestApplication(t)
 	defer application.Purge()
 
 	defaultMapping, err := application.GetDefaultAccountStoreMapping(MakeApplicationAccountStoreMappingCriteria())
@@ -335,10 +335,10 @@ func TestGetApplicationDefaultAccountStoreMapping(t *testing.T) {
 func TestGetOAuthTokenStormpathGrantType(t *testing.T) {
 	t.Parallel()
 
-	application := createTestApplication()
+	application := createTestApplication(t)
 	defer application.Purge()
 
-	account := createTestAccount(application)
+	account := createTestAccount(application, t)
 
 	claims := GrantTypeStormpathTokenClaims{}
 	claims.IssuedAt = time.Now().Unix()
@@ -364,10 +364,10 @@ func TestGetOAuthTokenStormpathGrantType(t *testing.T) {
 func TestApplicationGetAPIKey(t *testing.T) {
 	t.Parallel()
 
-	application := createTestApplication()
+	application := createTestApplication(t)
 	defer application.Purge()
 
-	account := createTestAccount(application)
+	account := createTestAccount(application, t)
 
 	apiKey, err := account.CreateAPIKey()
 	assert.NoError(t, err)

--- a/authenticators_test.go
+++ b/authenticators_test.go
@@ -10,10 +10,10 @@ import (
 func TestOAuthStormpathTokenAuthenticator(t *testing.T) {
 	t.Parallel()
 
-	application := createTestApplication()
+	application := createTestApplication(t)
 	defer application.Purge()
 
-	account := createTestAccount(application)
+	account := createTestAccount(application, t)
 
 	claims := GrantTypeStormpathTokenClaims{}
 	claims.IssuedAt = time.Now().Unix()
@@ -41,7 +41,7 @@ func TestOAuthStormpathTokenAuthenticator(t *testing.T) {
 func TestOAuthStormpathTokenAuthenticatorInvalidToken(t *testing.T) {
 	t.Parallel()
 
-	application := createTestApplication()
+	application := createTestApplication(t)
 	defer application.Purge()
 
 	authenticator := NewOAuthStormpathTokenAuthenticator(application)
@@ -56,10 +56,10 @@ func TestOAuthStormpathTokenAuthenticatorInvalidToken(t *testing.T) {
 func TestOAuthClientCredentialsAuthenticator(t *testing.T) {
 	t.Parallel()
 
-	application := createTestApplication()
+	application := createTestApplication(t)
 	defer application.Purge()
 
-	account := createTestAccount(application)
+	account := createTestAccount(application, t)
 	apiKey, _ := account.CreateAPIKey()
 
 	authenticator := NewOAuthClientCredentialsAuthenticator(application)
@@ -75,7 +75,7 @@ func TestOAuthClientCredentialsAuthenticator(t *testing.T) {
 func TestOAuthClientCredentialsAuthenticatorInvalidCredentials(t *testing.T) {
 	t.Parallel()
 
-	application := createTestApplication()
+	application := createTestApplication(t)
 	defer application.Purge()
 
 	authenticator := NewOAuthClientCredentialsAuthenticator(application)
@@ -90,7 +90,7 @@ func TestOAuthClientCredentialsAuthenticatorInvalidCredentials(t *testing.T) {
 func TestOAuthClientCredentialsAuthenticatorScopeFactory(t *testing.T) {
 	t.Parallel()
 
-	application := createTestApplication()
+	application := createTestApplication(t)
 	defer application.Purge()
 
 	authenticator := NewOAuthClientCredentialsAuthenticator(application)
@@ -108,10 +108,10 @@ func TestOAuthClientCredentialsAuthenticatorScopeFactory(t *testing.T) {
 func TestOAuthClientCredentialsAuthenticatorScopeFactoryValidScope(t *testing.T) {
 	t.Parallel()
 
-	application := createTestApplication()
+	application := createTestApplication(t)
 	defer application.Purge()
 
-	account := createTestAccount(application)
+	account := createTestAccount(application, t)
 	apiKey, _ := account.CreateAPIKey()
 
 	authenticator := NewOAuthClientCredentialsAuthenticator(application)
@@ -130,10 +130,10 @@ func TestOAuthClientCredentialsAuthenticatorScopeFactoryValidScope(t *testing.T)
 func TestBasicAuthenticator(t *testing.T) {
 	t.Parallel()
 
-	application := createTestApplication()
+	application := createTestApplication(t)
 	defer application.Purge()
 
-	account := createTestAccount(application)
+	account := createTestAccount(application, t)
 	apiKey, _ := account.CreateAPIKey()
 
 	authenticator := NewBasicAuthenticator(application)
@@ -147,7 +147,7 @@ func TestBasicAuthenticator(t *testing.T) {
 func TestBasicAuthenticatorInvalidCredentials(t *testing.T) {
 	t.Parallel()
 
-	application := createTestApplication()
+	application := createTestApplication(t)
 	defer application.Purge()
 
 	authenticator := NewBasicAuthenticator(application)
@@ -161,10 +161,10 @@ func TestBasicAuthenticatorInvalidCredentials(t *testing.T) {
 func TestBasicAuthenticatorDisabledCredentials(t *testing.T) {
 	t.Parallel()
 
-	application := createTestApplication()
+	application := createTestApplication(t)
 	defer application.Purge()
 
-	account := createTestAccount(application)
+	account := createTestAccount(application, t)
 	apiKey, _ := account.CreateAPIKey()
 	apiKey.Status = Disabled
 	apiKey.Update()
@@ -181,10 +181,10 @@ func TestBasicAuthenticatorDisabledCredentials(t *testing.T) {
 func TestBasicAuthenticatorDisabledAccount(t *testing.T) {
 	t.Parallel()
 
-	application := createTestApplication()
+	application := createTestApplication(t)
 	defer application.Purge()
 
-	account := createTestAccount(application)
+	account := createTestAccount(application, t)
 	apiKey, _ := account.CreateAPIKey()
 	account.Status = Disabled
 	account.Update()
@@ -201,10 +201,10 @@ func TestBasicAuthenticatorDisabledAccount(t *testing.T) {
 func TestBasicAuthenticatorInvalidSecret(t *testing.T) {
 	t.Parallel()
 
-	application := createTestApplication()
+	application := createTestApplication(t)
 	defer application.Purge()
 
-	account := createTestAccount(application)
+	account := createTestAccount(application, t)
 	apiKey, _ := account.CreateAPIKey()
 
 	authenticator := NewBasicAuthenticator(application)
@@ -219,10 +219,10 @@ func TestBasicAuthenticatorInvalidSecret(t *testing.T) {
 func TestOAuthPasswordAuthenticator(t *testing.T) {
 	t.Parallel()
 
-	application := createTestApplication()
+	application := createTestApplication(t)
 	defer application.Purge()
 
-	account := createTestAccount(application)
+	account := createTestAccount(application, t)
 
 	authenticator := NewOAuthPasswordAuthenticator(application)
 
@@ -237,10 +237,10 @@ func TestOAuthPasswordAuthenticator(t *testing.T) {
 func TestOAuthPasswordAuthenticatorInvalidCredentials(t *testing.T) {
 	t.Parallel()
 
-	application := createTestApplication()
+	application := createTestApplication(t)
 	defer application.Purge()
 
-	account := createTestAccount(application)
+	account := createTestAccount(application, t)
 
 	authenticator := NewOAuthPasswordAuthenticator(application)
 
@@ -254,10 +254,10 @@ func TestOAuthPasswordAuthenticatorInvalidCredentials(t *testing.T) {
 func TestOAuthRefreshTokenAuthenticator(t *testing.T) {
 	t.Parallel()
 
-	application := createTestApplication()
+	application := createTestApplication(t)
 	defer application.Purge()
 
-	account := createTestAccount(application)
+	account := createTestAccount(application, t)
 	oauthResponse, _ := application.GetOAuthToken(account.Username, "1234567z!A89")
 
 	authenticator := NewOAuthRefreshTokenAuthenticator(application)
@@ -273,7 +273,7 @@ func TestOAuthRefreshTokenAuthenticator(t *testing.T) {
 func TestOAuthRefreshTokenAuthenticatorInvalidToken(t *testing.T) {
 	t.Parallel()
 
-	application := createTestApplication()
+	application := createTestApplication(t)
 	defer application.Purge()
 
 	authenticator := NewOAuthRefreshTokenAuthenticator(application)

--- a/directory_test.go
+++ b/directory_test.go
@@ -21,7 +21,7 @@ func TestDirectoryJsonMarshaling(t *testing.T) {
 func TestGetDirectory(t *testing.T) {
 	t.Parallel()
 
-	directory := createTestDirectory()
+	directory := createTestDirectory(t)
 	defer directory.Delete()
 
 	d, err := GetDirectory(directory.Href, MakeDirectoryCriteria())
@@ -44,7 +44,7 @@ func TestGetDirectoryNotFound(t *testing.T) {
 func TestUpdateDirectory(t *testing.T) {
 	t.Parallel()
 
-	directory := createTestDirectory()
+	directory := createTestDirectory(t)
 	defer directory.Delete()
 
 	directory.Name = "newName" + randomName()
@@ -59,7 +59,7 @@ func TestUpdateDirectory(t *testing.T) {
 func TestDeleteDirectory(t *testing.T) {
 	t.Parallel()
 
-	directory := createTestDirectory()
+	directory := createTestDirectory(t)
 
 	err := directory.Delete()
 
@@ -69,7 +69,7 @@ func TestDeleteDirectory(t *testing.T) {
 func TestGetAccountCreationPolicy(t *testing.T) {
 	t.Parallel()
 
-	directory := createTestDirectory()
+	directory := createTestDirectory(t)
 	defer directory.Delete()
 
 	policy, err := directory.GetAccountCreationPolicy()
@@ -84,7 +84,7 @@ func TestGetAccountCreationPolicy(t *testing.T) {
 func TestGetDirectoryEmptyGroupsCollection(t *testing.T) {
 	t.Parallel()
 
-	directory := createTestDirectory()
+	directory := createTestDirectory(t)
 	defer directory.Delete()
 
 	groups, err := directory.GetGroups(MakeGroupsCriteria())
@@ -99,7 +99,7 @@ func TestGetDirectoryEmptyGroupsCollection(t *testing.T) {
 func TestGetDirectoryEmptyAccountsCollection(t *testing.T) {
 	t.Parallel()
 
-	directory := createTestDirectory()
+	directory := createTestDirectory(t)
 	defer directory.Delete()
 
 	accounts, err := directory.GetAccounts(MakeAccountsCriteria())
@@ -114,7 +114,7 @@ func TestGetDirectoryEmptyAccountsCollection(t *testing.T) {
 func TestDirectoryCreateGroup(t *testing.T) {
 	t.Parallel()
 
-	directory := createTestDirectory()
+	directory := createTestDirectory(t)
 	defer directory.Delete()
 
 	group := newTestGroup()
@@ -127,7 +127,7 @@ func TestDirectoryCreateGroup(t *testing.T) {
 func TestDirectoryRegisterAccount(t *testing.T) {
 	t.Parallel()
 
-	directory := createTestDirectory()
+	directory := createTestDirectory(t)
 	defer directory.Delete()
 
 	account := newTestAccount()

--- a/email_template_test.go
+++ b/email_template_test.go
@@ -9,7 +9,7 @@ import (
 func TestGetEmailTemplate(t *testing.T) {
 	t.Parallel()
 
-	directory := createTestDirectory()
+	directory := createTestDirectory(t)
 	defer directory.Delete()
 
 	policy, _ := directory.GetAccountCreationPolicy()
@@ -25,7 +25,7 @@ func TestGetEmailTemplate(t *testing.T) {
 func TestUpdateEmailTemplate(t *testing.T) {
 	t.Parallel()
 
-	directory := createTestDirectory()
+	directory := createTestDirectory(t)
 	defer directory.Delete()
 
 	policy, _ := directory.GetAccountCreationPolicy()
@@ -47,7 +47,7 @@ func TestUpdateEmailTemplate(t *testing.T) {
 func TestRefreshEmailTemplate(t *testing.T) {
 	t.Parallel()
 
-	directory := createTestDirectory()
+	directory := createTestDirectory(t)
 	defer directory.Delete()
 
 	policy, _ := directory.GetAccountCreationPolicy()

--- a/error.go
+++ b/error.go
@@ -21,7 +21,7 @@ func (e Error) Error() string {
 }
 
 func (e Error) String() string {
-	return e.Message
+	return e.Message + " " + e.DeveloperMessage
 }
 
 func handleResponseError(req *http.Request, resp *http.Response, err error) error {

--- a/group_membership_test.go
+++ b/group_membership_test.go
@@ -10,13 +10,13 @@ import (
 func TestGetGroupMembershipAccount(t *testing.T) {
 	t.Parallel()
 
-	application := createTestApplication()
+	application := createTestApplication(t)
 	defer application.Purge()
 
-	group := createTestGroup(application)
+	group := createTestGroup(application, t)
 	defer group.Delete()
 
-	account := createTestAccount(application)
+	account := createTestAccount(application, t)
 
 	groupMembership, _ := account.AddToGroup(group)
 
@@ -42,13 +42,13 @@ func TestGetGroupMembershipAccountNotFound(t *testing.T) {
 func TestGetGroupMembershipGroup(t *testing.T) {
 	t.Parallel()
 
-	application := createTestApplication()
+	application := createTestApplication(t)
 	defer application.Purge()
 
-	group := createTestGroup(application)
+	group := createTestGroup(application, t)
 	defer group.Delete()
 
-	account := createTestAccount(application)
+	account := createTestAccount(application, t)
 
 	groupMembership, _ := account.AddToGroup(group)
 

--- a/group_test.go
+++ b/group_test.go
@@ -21,10 +21,10 @@ func TestGroupJsonMarshaling(t *testing.T) {
 func TestGetGroup(t *testing.T) {
 	t.Parallel()
 
-	application := createTestApplication()
+	application := createTestApplication(t)
 	defer application.Purge()
 
-	group := createTestGroup(application)
+	group := createTestGroup(application, t)
 	defer group.Delete()
 
 	existingGroup, err := GetGroup(group.Href, MakeGroupCriteria())
@@ -46,10 +46,10 @@ func TestGetGroupNotFound(t *testing.T) {
 func TestGroupRefresh(t *testing.T) {
 	t.Parallel()
 
-	application := createTestApplication()
+	application := createTestApplication(t)
 	defer application.Purge()
 
-	group := createTestGroup(application)
+	group := createTestGroup(application, t)
 	defer group.Delete()
 
 	g := &Group{}
@@ -75,10 +75,10 @@ func TestGroupRefreshNotFound(t *testing.T) {
 func TestUpdateGroup(t *testing.T) {
 	t.Parallel()
 
-	application := createTestApplication()
+	application := createTestApplication(t)
 	defer application.Purge()
 
-	group := createTestGroup(application)
+	group := createTestGroup(application, t)
 	defer group.Delete()
 
 	group.Name = "newName" + randomName()
@@ -93,10 +93,10 @@ func TestUpdateGroup(t *testing.T) {
 func TestGetGroupAccountMemberships(t *testing.T) {
 	t.Parallel()
 
-	application := createTestApplication()
+	application := createTestApplication(t)
 	defer application.Purge()
 
-	group := createTestGroup(application)
+	group := createTestGroup(application, t)
 	defer group.Delete()
 
 	gm, err := group.GetGroupAccountMemberships(MakeGroupMemershipsCriteria())

--- a/oauth_policy_test.go
+++ b/oauth_policy_test.go
@@ -10,7 +10,7 @@ import (
 func TestGetApplicationOAuthPolicy(t *testing.T) {
 	t.Parallel()
 
-	application := createTestApplication()
+	application := createTestApplication(t)
 	defer application.Purge()
 
 	policy, err := application.GetOAuthPolicy()
@@ -23,7 +23,7 @@ func TestGetApplicationOAuthPolicy(t *testing.T) {
 func TestUpdateApplicationOAuthPolicy(t *testing.T) {
 	t.Parallel()
 
-	application := createTestApplication()
+	application := createTestApplication(t)
 	defer application.Purge()
 
 	policy, _ := application.GetOAuthPolicy()
@@ -43,7 +43,7 @@ func TestUpdateApplicationOAuthPolicy(t *testing.T) {
 func TestUpdateApplicationOAuthPolicyInvalidTTL(t *testing.T) {
 	t.Parallel()
 
-	application := createTestApplication()
+	application := createTestApplication(t)
 	defer application.Purge()
 
 	policy, _ := application.GetOAuthPolicy()

--- a/organization_test.go
+++ b/organization_test.go
@@ -20,7 +20,7 @@ func TestOrganizationJsonMarshaling(t *testing.T) {
 func TestUpdateOrganization(t *testing.T) {
 	t.Parallel()
 
-	org := createTestOrganization()
+	org := createTestOrganization(t)
 	defer org.Delete()
 
 	org.Name = "new-name" + randomName()
@@ -37,7 +37,7 @@ func TestUpdateOrganization(t *testing.T) {
 func TestRefreshOrganization(t *testing.T) {
 	t.Parallel()
 
-	org := createTestOrganization()
+	org := createTestOrganization(t)
 	defer org.Delete()
 
 	newName := "new-name" + randomName()
@@ -51,10 +51,10 @@ func TestRefreshOrganization(t *testing.T) {
 func TestGetOrganizationDefaultAccountStoreMapping(t *testing.T) {
 	t.Parallel()
 
-	org := createTestOrganization()
+	org := createTestOrganization(t)
 	defer org.Delete()
 
-	directory := createTestDirectory()
+	directory := createTestDirectory(t)
 	defer directory.Delete()
 
 	mapping := NewOrganizationAccountStoreMapping(org.Href, directory.Href)
@@ -73,10 +73,10 @@ func TestGetOrganizationDefaultAccountStoreMapping(t *testing.T) {
 func TestOrganizationRegisterAccount(t *testing.T) {
 	t.Parallel()
 
-	org := createTestOrganization()
+	org := createTestOrganization(t)
 	defer org.Delete()
 
-	directory := createTestDirectory()
+	directory := createTestDirectory(t)
 	defer directory.Delete()
 
 	mapping := NewOrganizationAccountStoreMapping(org.Href, directory.Href)

--- a/stormpath_suite_test.go
+++ b/stormpath_suite_test.go
@@ -93,32 +93,43 @@ func newTestOrganization() *Organization {
 	return NewOrganization("go-sdk-org-"+randomName(), "go-sdk-org-"+randomName())
 }
 
-func createTestApplication() *Application {
+func createTestApplication(t *testing.T) *Application {
 	application := newTestApplication()
-	tenant.CreateApplication(application)
+	e := tenant.CreateApplication(application)
+	failOnError(e, t)
 	return application
 }
 
-func createTestOrganization() *Organization {
+func createTestOrganization(t *testing.T) *Organization {
 	organization := newTestOrganization()
-	tenant.CreateOrganization(organization)
+	e := tenant.CreateOrganization(organization)
+	failOnError(e, t)
 	return organization
 }
 
-func createTestAccount(application *Application) *Account {
+func createTestAccount(application *Application, t *testing.T) *Account {
 	account := newTestAccount()
-	application.RegisterAccount(account)
+	e := application.RegisterAccount(account)
+	failOnError(e, t)
 	return account
 }
 
-func createTestGroup(application *Application) *Group {
+func createTestGroup(application *Application, t *testing.T) *Group {
 	group := newTestGroup()
-	application.CreateGroup(group)
+	e := application.CreateGroup(group)
+	failOnError(e, t)
 	return group
 }
 
-func createTestDirectory() *Directory {
+func createTestDirectory(t *testing.T) *Directory {
 	directory := newTestDirectory()
-	tenant.CreateDirectory(directory)
+	e := tenant.CreateDirectory(directory)
+	failOnError(e, t)
 	return directory
+}
+
+func failOnError(e error, t *testing.T) {
+	if e != nil {
+		t.Fatal(e)
+	}
 }

--- a/tenant_test.go
+++ b/tenant_test.go
@@ -53,6 +53,8 @@ func TestGetCurrentTenant(t *testing.T) {
 	assert.NotEmpty(t, currentTenant.Directories.Href)
 }
 
+//TODO: Fix panic: runtime error: invalid memory address or nil pointer dereference
+// This error is caused by Purge() method when there were errors during application creation.
 func TestTenantCreateApplication(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Context: I run the whole suit of tests and got a loads of:
Fix panic: runtime error: invalid memory address or nil pointer dereference.

The main reason why most of the tests failed was application limit which is by default set to 2(At most you can have 2 applications).
The error I was presented was "Oops! We encountered an unexpected error.  Please contact support and explain what you were doing at the time this error occurred."
I had to manually fire curl with verbose mode to see the whole response returned by the stormpath.
Thus I decided to extend msg returned by String() method on Error type by developerMessage.

To fix nil pointer dereference test methods that creates applications, directories etc.
will examine the output returned by the SDK and fail accordingly.