### PR TITLE
add ability to specify the Organization, Directory, or Group in Password Reset function

### DIFF
--- a/application.go
+++ b/application.go
@@ -198,11 +198,16 @@ func (app *Application) ResendVerificationEmail(email string) error {
 //SendPasswordResetEmail triggers a send of the password reset email in Stormpath for a given email address.
 //
 //For more info on the Stormpath password reset workflow see: http://docs.stormpath.com/rest/product-guide/latest/accnt_mgmt.html#password-reset-flow
-func (app *Application) SendPasswordResetEmail(email string) (*AccountPasswordResetToken, error) {
+func (app *Application) SendPasswordResetEmail(email, accountStoreHref string) (*AccountPasswordResetToken, error) {
 	passwordResetToken := &AccountPasswordResetToken{}
 
-	passwordResetPayload := make(map[string]string)
+	passwordResetPayload := make(map[string]interface{})
 	passwordResetPayload["email"] = email
+	if accountStoreHref != "" {
+		passwordResetPayload["accountStore"] = map[string]string{
+			"href": accountStoreHref,
+		}
+	}
 
 	err := client.post(buildAbsoluteURL(app.Href, "passwordResetTokens"), passwordResetPayload, passwordResetToken)
 

--- a/application_test.go
+++ b/application_test.go
@@ -194,7 +194,7 @@ func TestSendPasswordResetEmail(t *testing.T) {
 
 	account := createTestAccount(application, t)
 
-	token, err := application.SendPasswordResetEmail(account.Email)
+	token, err := application.SendPasswordResetEmail(account.Email, "")
 
 	assert.NoError(t, err)
 	assert.NotEmpty(t, token)
@@ -208,7 +208,7 @@ func TestResetPassword(t *testing.T) {
 
 	account := createTestAccount(application, t)
 
-	token, _ := application.SendPasswordResetEmail(account.Email)
+	token, _ := application.SendPasswordResetEmail(account.Email, "")
 
 	re := regexp.MustCompile("[^\\/]+$")
 
@@ -226,7 +226,7 @@ func TestValidatePasswordResetToken(t *testing.T) {
 
 	account := createTestAccount(application, t)
 
-	token, _ := application.SendPasswordResetEmail(account.Email)
+	token, _ := application.SendPasswordResetEmail(account.Email, "")
 
 	re := regexp.MustCompile("[^\\/]+$")
 

--- a/application_test.go
+++ b/application_test.go
@@ -200,6 +200,21 @@ func TestSendPasswordResetEmail(t *testing.T) {
 	assert.NotEmpty(t, token)
 }
 
+func TestSendPasswordResetEmailWithAccStore(t *testing.T) {
+	t.Parallel()
+
+	application := createTestApplication(t)
+	defer application.Purge()
+
+	account := createTestAccount(application, t)
+
+	//account store: Organization, Directory or Group
+	token, err := application.SendPasswordResetEmail(account.Email, account.Directory.Href)
+
+	assert.NoError(t, err)
+	assert.NotEmpty(t, token)
+}
+
 func TestResetPassword(t *testing.T) {
 	t.Parallel()
 
@@ -218,6 +233,25 @@ func TestResetPassword(t *testing.T) {
 	assert.Equal(t, account.Href, a.Href)
 }
 
+func TestResetPasswordWithAccStore(t *testing.T) {
+	t.Parallel()
+
+	application := createTestApplication(t)
+	defer application.Purge()
+
+	account := createTestAccount(application, t)
+
+	//account store: Organization, Directory or Group
+	token, _ := application.SendPasswordResetEmail(account.Email, account.Directory.Href)
+
+	re := regexp.MustCompile("[^\\/]+$")
+
+	a, err := application.ResetPassword(re.FindString(token.Href), "8787987!kJKJdfW")
+
+	assert.NoError(t, err)
+	assert.Equal(t, account.Href, a.Href)
+}
+
 func TestValidatePasswordResetToken(t *testing.T) {
 	t.Parallel()
 
@@ -227,6 +261,25 @@ func TestValidatePasswordResetToken(t *testing.T) {
 	account := createTestAccount(application, t)
 
 	token, _ := application.SendPasswordResetEmail(account.Email, "")
+
+	re := regexp.MustCompile("[^\\/]+$")
+
+	validatedToken, err := application.ValidatePasswordResetToken(re.FindString(token.Href))
+
+	assert.NoError(t, err)
+	assert.Equal(t, token.Href, validatedToken.Href)
+}
+
+func TestValidatePasswordResetTokenWithAccStore(t *testing.T) {
+	t.Parallel()
+
+	application := createTestApplication(t)
+	defer application.Purge()
+
+	account := createTestAccount(application, t)
+
+	//account store: Organization, Directory or Group
+	token, _ := application.SendPasswordResetEmail(account.Email, account.Directory.Href)
 
 	re := regexp.MustCompile("[^\\/]+$")
 

--- a/web/assets.go
+++ b/web/assets.go
@@ -289,12 +289,12 @@ func AssetNames() []string {
 var _bindata = map[string]func() (*asset, error){
 	"templates/change-password.html": templatesChangePasswordHtml,
 	"templates/forgot-password.html": templatesForgotPasswordHtml,
-	"templates/login.html": templatesLoginHtml,
-	"templates/register.html": templatesRegisterHtml,
-	"templates/verify.html": templatesVerifyHtml,
-	"assets/css/stormpath.css": assetsCssStormpathCss,
-	"assets/js/social-login.js": assetsJsSocialLoginJs,
-	"config/web.stormpath.yaml": configWebStormpathYaml,
+	"templates/login.html":           templatesLoginHtml,
+	"templates/register.html":        templatesRegisterHtml,
+	"templates/verify.html":          templatesVerifyHtml,
+	"assets/css/stormpath.css":       assetsCssStormpathCss,
+	"assets/js/social-login.js":      assetsJsSocialLoginJs,
+	"config/web.stormpath.yaml":      configWebStormpathYaml,
 }
 
 // AssetDir returns the file names below a certain
@@ -336,6 +336,7 @@ type bintree struct {
 	Func     func() (*asset, error)
 	Children map[string]*bintree
 }
+
 var _bintree = &bintree{nil, map[string]*bintree{
 	"assets": &bintree{nil, map[string]*bintree{
 		"css": &bintree{nil, map[string]*bintree{
@@ -351,9 +352,9 @@ var _bintree = &bintree{nil, map[string]*bintree{
 	"templates": &bintree{nil, map[string]*bintree{
 		"change-password.html": &bintree{templatesChangePasswordHtml, map[string]*bintree{}},
 		"forgot-password.html": &bintree{templatesForgotPasswordHtml, map[string]*bintree{}},
-		"login.html": &bintree{templatesLoginHtml, map[string]*bintree{}},
-		"register.html": &bintree{templatesRegisterHtml, map[string]*bintree{}},
-		"verify.html": &bintree{templatesVerifyHtml, map[string]*bintree{}},
+		"login.html":           &bintree{templatesLoginHtml, map[string]*bintree{}},
+		"register.html":        &bintree{templatesRegisterHtml, map[string]*bintree{}},
+		"verify.html":          &bintree{templatesVerifyHtml, map[string]*bintree{}},
 	}},
 }}
 
@@ -403,4 +404,3 @@ func _filePath(dir, name string) string {
 	cannonicalName := strings.Replace(name, "\\", "/", -1)
 	return filepath.Join(append([]string{dir}, strings.Split(cannonicalName, "/")...)...)
 }
-

--- a/web/forgot_password.go
+++ b/web/forgot_password.go
@@ -65,7 +65,7 @@ func (h forgotPasswordHandler) doPOST(w http.ResponseWriter, r *http.Request, ct
 		return
 	}
 
-	h.application.SendPasswordResetEmail(data["email"])
+	h.application.SendPasswordResetEmail(data["email"], "")
 
 	if contentType == stormpath.ApplicationJSON {
 		respondJSON(w, nil, http.StatusOK)

--- a/web/forgot_password.go
+++ b/web/forgot_password.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"net/http"
 
+	"bytes"
+	"encoding/json"
 	"github.com/jarias/stormpath-sdk-go"
 )
 
@@ -58,14 +60,16 @@ func (h forgotPasswordHandler) doGET(w http.ResponseWriter, r *http.Request, ctx
 func (h forgotPasswordHandler) doPOST(w http.ResponseWriter, r *http.Request, ctx webContext) {
 	contentType := ctx.contentType
 
-	data, _ := getPostedData(r)
+	data, originalData := getPostedData(r)
 
 	if data["email"] == "" {
 		handleError(w, r, ctx.withError(nil, fmt.Errorf("email is required")), h.doGET)
 		return
 	}
 
-	h.application.SendPasswordResetEmail(data["email"], "")
+	accStoreHref := getAccStoreHref(originalData)
+
+	h.application.SendPasswordResetEmail(data["email"], accStoreHref)
 
 	if contentType == stormpath.ApplicationJSON {
 		respondJSON(w, nil, http.StatusOK)
@@ -88,4 +92,27 @@ func resolveForgotPasswordStatus(status string) string {
 	}
 
 	return statusMessage
+}
+
+func getAccStoreHref(originalData []byte) string {
+	data := make(map[string]interface{})
+	if err := json.NewDecoder(bytes.NewBuffer(originalData)).Decode(&data); err != nil {
+		//log if necessary
+		return ""
+	}
+
+	if v, ok := data["accountStore"]; !ok {
+		//log if necessary
+		return ""
+	} else {
+		if accStoreMap, ok := v.(map[string]string); ok {
+			if href, ok := accStoreMap["href"]; ok {
+				return href
+			} else {
+				return ""
+			}
+		} else {
+			return ""
+		}
+	}
 }


### PR DESCRIPTION
Hi,

I have added an option to specify the Organization, Directory, or Group in Password Reset function,
(https://docs.stormpath.com/rest/product-guide/latest/accnt_mgmt.html#password-reset-flow).
It can be useful, for instance, when you use one application with few directories. Unfortunately, I cannot run your tests, because i'm using "Developer Plan", and I get the following message "Application limit reached".

Best regargs,
Igor